### PR TITLE
Travis: Install Bioconductor packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ r:
   - oldrel
   - release
   - devel
+bioc_packages:
+  - annotate
+  - ComplexHeatmap
+  


### PR DESCRIPTION
Build is failing because Bioconductor packages are not installed. This change installs them explicitly.