### PR TITLE
Travis: Add Bioconductor dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ r:
   - oldrel
   - release
   - devel
+bioc_packages:
+  - ComplexHeatmap
+  - annotate


### PR DESCRIPTION
This should fix the Travis builds that currently fail because Bioconductor packages could not be found.