### PR TITLE
Advise users to install optional dependencies too

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Agustin Gonzalez-Reymundez, Alexander Grueneberg, and Ana I. Vazquez.
 
 ```
 library(devtools)
-install_github("agugonrey/MOSS")
+install_github("agugonrey/MOSS", dependencies = TRUE)
 library("MOSS")
 ```
 


### PR DESCRIPTION
Passing `dependencies = TRUE` will install packages from `Suggests:` as well. It may be convenient to have everything installed? Up to you.